### PR TITLE
Add css Grid properties, all property, additonal justify properties

### DIFF
--- a/style3.css
+++ b/style3.css
@@ -32,6 +32,9 @@
 
 #Concentric-CSS-Complete {
   /* All CSS properties, in roughly the order I use when being careful */
+	
+	/* added all property -- this resets all properties (except direction) to initial value */
+	all: ;
 
   /* box-sizing */
   /* [content-box|border-box|inherit|initial|unset]*/ ;
@@ -44,14 +47,10 @@
   right: ;
   bottom: ;
   left: ;
-  
+
+  /* floats */
   float: ;
   clear: ;
-
-  /* align-content */
-  align-content: ;
-  align-items: ;
-  align-self: ;
   
   /* flex  */
   flex: ;
@@ -61,11 +60,39 @@
   flex-grow: ;
   flex-shrink: ;
   flex-wrap: ;
+  
+  /* grid */
+  grid: ;
+  grid-area: ;
+  grid-template: ;
+	grid-template-areas: ;
+	grid-template-rows: ;
+	grid-template-columns: ;
+	grid-row: ;
+	grid-row-start: ;
+	grid-row-end: ;
+	grid-column: ;
+	grid-column-start: ;
+	grid-column-end: ;
+	grid-auto-rows: ;
+	grid-auto-columns: ;
+	grid-auto-flow: ;
+	grid-gap: ;
+	grid-row-gap: ;
+	grid-column-gap': ;
+	
+  /* align-content */
+  align-content: ;
+  align-items: ;
+  align-self: ;
+	
+	/* justify-content */
   justify-content: ;
+  justify-items: ;
+  justify-self: ;
 
   /* order */
   order: ;
-
 
   /* columns */
   columns: ;
@@ -79,7 +106,6 @@
   column-count: ;
   column-width: ;
 
-
   /* transform */
   backface-visibility: ;
   perspective: ;
@@ -87,7 +113,6 @@
   transform: ;
   transform-origin: ;
   transform-style: ;
-
 
   /* tranistions */
   transition: ;


### PR DESCRIPTION
1. Adds `all` property as first item as it can reset nearly all initial  properties to their default values.
2. Moves `align-content` properties to follow flexbox and grid properties.
3. Adds all css grid perperties
4. Adds `justify-items` and `justify-self` and groups with 'justify-content'

**Explanation**
1. I'm not entirely certain this is the correct placement for this, but my rationale is that, because it can potentially mean changes to the box-model property, it should precede it.
2. The rational for this is that these properties alter the behaviour _inside_ `flexbox` or `grid`, so they should come later.
